### PR TITLE
Disable original MapAlloc implementation

### DIFF
--- a/include/mb/linux_overrides.h
+++ b/include/mb/linux_overrides.h
@@ -8,12 +8,9 @@
 
 #ifndef _WIN32
 
-#include <cstring>    // memset
 #include <strings.h>  // strcasecmp
 
 inline int _stricmp(const char* a, const char* b) { return strcasecmp(a, b); }
-
-#define ZeroMemory(a, b) memset(a, 0, b)
 
 #define sscanf_s sscanf
 

--- a/include/mb/linux_overrides.h
+++ b/include/mb/linux_overrides.h
@@ -15,11 +15,7 @@ inline int _stricmp(const char* a, const char* b) { return strcasecmp(a, b); }
 
 #define ZeroMemory(a, b) memset(a, 0, b)
 
-#define sprintf_s sprintf
-
 #define sscanf_s sscanf
-
-#define strcpy_s(a, b) strcpy(a, b)
 
 inline void* _aligned_malloc(std::size_t size, int boundary) {
   return memalign(boundary, size);

--- a/include/mb/mapalloc.h
+++ b/include/mb/mapalloc.h
@@ -1,15 +1,23 @@
 #pragma once
 
+#include <cstddef>
 #include <memory>
-#include <vector>
-
-#ifdef _WIN32
-#define NOMINMAX
-#include <Windows.h>
-#endif
 
 namespace multiblend::memory {
 
+class MapAlloc {
+ public:
+  static void* Alloc(std::size_t size, int alignment = 16);
+  static void Free(void* p);
+  static void CacheThreshold(std::size_t limit);
+  static void SetTmpdir(const char* _tmpdir);
+
+ private:
+};
+
+// TODO(krupkat): cleanup the original MapAlloc class
+
+/*
 class MapAlloc {
  private:
   class MapAllocObject {
@@ -47,6 +55,7 @@ class MapAlloc {
   static bool LastFile() { return objects_.back()->IsFile(); }
   // static bool last_mapped;
 };
+*/
 
 class MapAllocDeleter {
  public:

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -311,6 +311,9 @@ void Image::Open() {
       xpos_ = ypos_ = 0;
       tiff_xres_ = tiff_yres_ = 90;
     } break;
+    default: {
+      utils::Throw("Unknown image type ({})", filename_);
+    }
   }
 
   xpos_ += xpos_add_;
@@ -370,6 +373,9 @@ void Image::Read(void* data, bool gamma) {
       memcpy(data, image_->data.data(), size_bytes);
       image_.reset();
     } break;
+    default: {
+      utils::Throw("Unknown image type ({})", filename_);
+    }
   }
 
   /***********************************************************************

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -368,6 +368,7 @@ void Image::Read(void* data, bool gamma) {
     case ImageType::MB_IN_MEMORY: {
       auto size_bytes = image_->data.size() << (bpp_ >> 4);
       memcpy(data, image_->data.data(), size_bytes);
+      image_.reset();
     } break;
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -720,6 +720,9 @@ http://horman.net/multiblend/
         case io::ImageType::MB_PNG: {
           png_file->WriteRows(scanlines.get(), rows);
         } break;
+        default: {
+          utils::Throw("Unknown image type ({})", output_filename);
+        }
       }
 
       remaining -= rows_per_strip;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -501,6 +501,9 @@ http://horman.net/multiblend/
       }
       jpeg_file = {tmp_jpeg_file, io::FileDeleter{}};
     } break;
+    default: {
+      utils::Throw("Unknown image type ({})", output_filename);
+    }
   }
 
   /***********************************************************************
@@ -624,6 +627,9 @@ http://horman.net/multiblend/
                            : io::png::ColorType::RGB_ALPHA,
             result.output_bpp, std::move(jpeg_file), jpeg_quality);
       } break;
+      default: {
+        utils::Throw("Unknown image type ({})", output_filename);
+      }
     }
 
     if (output_type == io::ImageType::MB_PNG ||

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -677,10 +678,10 @@ http://horman.net/multiblend/
             std::size_t t = (std::size_t)cur * bytes_per_pixel;
             switch (result.output_bpp) {
               case 8: {
-                ZeroMemory(&(strip.get())[strip_p], t);
+                memset(&(strip.get())[strip_p], 0, t);
               } break;
               case 16: {
-                ZeroMemory(&((uint16_t*)strip.get())[strip_p], t);
+                memset(&((uint16_t*)strip.get())[strip_p], 0, t);
               } break;
             }
             strip_p += cur * spp;

--- a/src/mapalloc.cpp
+++ b/src/mapalloc.cpp
@@ -28,9 +28,9 @@ int MapAlloc::suffix_ = 0;
 std::size_t MapAlloc::cache_threshold_ = ~(std::size_t)0;
 std::size_t MapAlloc::total_allocated_ = 0;
 
-//***********************************************************************
-//* MapAlloc
-//***********************************************************************
+// ***********************************************************************
+// * MapAlloc
+// ***********************************************************************
 void MapAlloc::CacheThreshold(std::size_t limit) { cache_threshold_ = limit; }
 
 void* MapAlloc::Alloc(std::size_t size, int alignment) {
@@ -67,9 +67,9 @@ void MapAlloc::SetTmpdir(const char* _tmpdir) {
   }
 }
 
-//***********************************************************************
-//* MapAllocObject
-//***********************************************************************
+// ***********************************************************************
+// * MapAllocObject
+// ***********************************************************************
 MapAlloc::MapAllocObject::MapAllocObject(std::size_t size, int alignment)
     : size_(size) {
   if (total_allocated_ + size_ < cache_threshold_) {

--- a/src/mapalloc.cpp
+++ b/src/mapalloc.cpp
@@ -1,20 +1,26 @@
 #include "mb/mapalloc.h"
 
-#include <cstring>
-#include <stdexcept>
-
-#ifndef _WIN32
-#include <cerrno>
-#include <cstdlib>
-#include <unistd.h>
-
-#include <sys/mman.h>
-#endif
-
 #include "mb/linux_overrides.h"
+#include "mb/logging.h"
 
 namespace multiblend::memory {
 
+void* MapAlloc::Alloc(std::size_t size, int alignment) {
+  return _aligned_malloc(size, alignment);
+}
+
+void MapAlloc::Free(void* p) { _aligned_free(p); }
+
+void MapAlloc::CacheThreshold(std::size_t limit) {
+  utils::Throw("MapAlloc::CacheThreshold not implemented");
+}
+
+void MapAlloc::SetTmpdir(const char* _tmpdir) {
+  utils::Throw("MapAlloc::SetTmpdir not implemented");
+}
+
+// TODO(krupkat): cleanup the original MapAlloc class
+/*
 std::vector<MapAlloc::MapAllocObject*> MapAlloc::objects_;
 char MapAlloc::tmpdir_[256] = "";
 char MapAlloc::filename_[512];
@@ -22,9 +28,9 @@ int MapAlloc::suffix_ = 0;
 std::size_t MapAlloc::cache_threshold_ = ~(std::size_t)0;
 std::size_t MapAlloc::total_allocated_ = 0;
 
-/***********************************************************************
- * MapAlloc
- ***********************************************************************/
+//***********************************************************************
+//* MapAlloc
+//***********************************************************************
 void MapAlloc::CacheThreshold(std::size_t limit) { cache_threshold_ = limit; }
 
 void* MapAlloc::Alloc(std::size_t size, int alignment) {
@@ -61,9 +67,9 @@ void MapAlloc::SetTmpdir(const char* _tmpdir) {
   }
 }
 
-/***********************************************************************
- * MapAllocObject
- ***********************************************************************/
+//***********************************************************************
+//* MapAllocObject
+//***********************************************************************
 MapAlloc::MapAllocObject::MapAllocObject(std::size_t size, int alignment)
     : size_(size) {
   if (total_allocated_ + size_ < cache_threshold_) {
@@ -191,5 +197,7 @@ bool MapAlloc::MapAllocObject::IsFile() const {
   return file_ != 0;
 #endif
 }
+
+*/
 
 }  // namespace multiblend::memory

--- a/src/pyramid.cpp
+++ b/src/pyramid.cpp
@@ -6,6 +6,7 @@
 #endif
 
 #include <cmath>
+#include <cstring>
 
 #include "mb/aligned_ptr.h"
 #include "mb/linux_overrides.h"
@@ -1133,9 +1134,9 @@ void Pyramid::Multiply(int level, float mul) {
     return;
   }
   if (mul == 0) {
-    ZeroMemory(levels_[level].data.get(),
-               static_cast<std::size_t>(levels_[level].height) *
-                   levels_[level].pitch * sizeof(float));
+    memset(levels_[level].data.get(), 0,
+           static_cast<std::size_t>(levels_[level].height) *
+               levels_[level].pitch * sizeof(float));
     return;
   }
 


### PR DESCRIPTION
- Disabling original MapAlloc implementation for now - untested, using unsafe c functions
- Removing some platform specific stuff
- Cleanup for compiler warnings