### PR TITLE
Remove platform specific memory alignment

### DIFF
--- a/include/mb/aligned_ptr.h
+++ b/include/mb/aligned_ptr.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <immintrin.h>
+#include <new>
 
 namespace multiblend::memory {
 
@@ -10,8 +11,9 @@ namespace multiblend::memory {
 class AlignedM128Ptr {
   // RAII class for an array of __m128
  public:
+  static constexpr std::align_val_t kAlignment = std::align_val_t{16};
+
   AlignedM128Ptr() = default;
-  explicit AlignedM128Ptr(__m128* ptr) : ptr_(ptr) {}
   ~AlignedM128Ptr();
 
   AlignedM128Ptr(const AlignedM128Ptr& other) = delete;
@@ -25,6 +27,12 @@ class AlignedM128Ptr {
   const __m128& operator[](int i) const { return ptr_[i]; }
 
  private:
+  explicit AlignedM128Ptr(__m128* ptr) : ptr_(ptr) {}
   __m128* ptr_ = nullptr;
+
+  friend AlignedM128Ptr AllocAlignedM128(std::size_t size_bytes);
 };
+
+AlignedM128Ptr AllocAlignedM128(std::size_t size_bytes);
+
 }  // namespace multiblend::memory

--- a/include/mb/image.h
+++ b/include/mb/image.h
@@ -42,10 +42,10 @@ enum class ImageType { MB_NONE, MB_TIFF, MB_JPEG, MB_PNG, MB_IN_MEMORY };
 class Channel {
  public:
   explicit Channel(std::size_t bytes) : bytes_(bytes) {
-    data_ = memory::MapAllocPtr<void>{memory::MapAlloc::Alloc(bytes_)};
+    data_ = memory::AllocAligned<void>(bytes_);
   };
 
-  memory::MapAllocPtr<void> data_ = nullptr;
+  memory::AlignedAllocPtr<void> data_ = nullptr;
   std::size_t bytes_;
 };
 

--- a/include/mb/linux_overrides.h
+++ b/include/mb/linux_overrides.h
@@ -1,24 +1,13 @@
 #pragma once
 
-#ifdef __APPLE__
-#define memalign(a, b) malloc((b))
-#else
-#include <malloc.h>  // memalign
-#endif
-
 #ifndef _WIN32
 
+#include <cstdio>     // fopen
 #include <strings.h>  // strcasecmp
 
 inline int _stricmp(const char* a, const char* b) { return strcasecmp(a, b); }
 
 #define sscanf_s sscanf
-
-inline void* _aligned_malloc(std::size_t size, int boundary) {
-  return memalign(boundary, size);
-}
-
-inline void _aligned_free(void* a) { free(a); }
 
 inline void fopen_s(FILE** f, const char* filename, const char* mode) {
   *f = fopen(filename, mode);

--- a/include/mb/multiblend.h
+++ b/include/mb/multiblend.h
@@ -45,7 +45,7 @@ struct Result {
   int height = 0;
   bool no_mask = false;
 
-  std::array<memory::MapAllocPtr<void>, 3> output_channels;
+  std::array<memory::AlignedAllocPtr<void>, 3> output_channels;
   int min_xpos = 0x7fffffff;
   int min_ypos = 0x7fffffff;
 

--- a/src/aligned_ptr.cpp
+++ b/src/aligned_ptr.cpp
@@ -6,10 +6,13 @@
 
 namespace multiblend::memory {
 
+AlignedM128Ptr AllocAlignedM128(std::size_t size_bytes) {
+  return AlignedM128Ptr(static_cast<__m128*>(
+      ::operator new(size_bytes, AlignedM128Ptr::kAlignment)));
+}
+
 AlignedM128Ptr::~AlignedM128Ptr() {
-  if (ptr_ != nullptr) {
-    _aligned_free(ptr_);
-  }
+  ::operator delete(ptr_, AlignedM128Ptr::kAlignment);
 }
 
 AlignedM128Ptr::AlignedM128Ptr(AlignedM128Ptr&& other) noexcept {
@@ -18,9 +21,8 @@ AlignedM128Ptr::AlignedM128Ptr(AlignedM128Ptr&& other) noexcept {
 
 AlignedM128Ptr& AlignedM128Ptr::operator=(AlignedM128Ptr&& other) noexcept {
   if (this != &other) {
-    if (ptr_ != nullptr) {
-      _aligned_free(ptr_);
-    }
+    ::operator delete(ptr_, AlignedM128Ptr::kAlignment);
+
     ptr_ = other.ptr_;
     other.ptr_ = nullptr;
   }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -30,6 +30,7 @@ void SafeRealloc(std::unique_ptr<uint8_t, FreeDeleter>& data, size_t size) {
       tmp) {
     data.release();  // NOLINT(bugprone-unused-return-value): used in realloc
     data = std::move(tmp);
+    return;
   }
   throw std::runtime_error("out of memory");
 }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -5,12 +5,121 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <stdexcept>
 #include <vector>
 
 #include "mb/logging.h"
 #include "mb/pyramid.h"
 
 namespace multiblend::utils {
+
+namespace {
+std::unique_ptr<uint8_t, FreeDeleter> SafeMalloc(size_t size) {
+  if (auto tmp = std::unique_ptr<uint8_t, FreeDeleter>{(uint8_t*)malloc(size),
+                                                       FreeDeleter{}};
+      tmp) {
+    return tmp;
+  }
+  throw std::runtime_error("out of memory");
+}
+
+void SafeRealloc(std::unique_ptr<uint8_t, FreeDeleter>& data, size_t size) {
+  if (auto tmp =
+          std::unique_ptr<uint8_t, FreeDeleter>{
+              (uint8_t*)realloc(data.get(), size), FreeDeleter{}};
+      tmp) {
+    data.release();  // NOLINT(bugprone-unused-return-value): used in realloc
+    data = std::move(tmp);
+  }
+  throw std::runtime_error("out of memory");
+}
+}  // namespace
+
+/***********************************************************************
+ * Flexible data class
+ ***********************************************************************/
+void Flex::NextLine() {
+  end_p_ = p_;
+  if (y_ < height_ - 1) {
+    rows_[++y_] = p_;
+  }
+
+  if (p_ + (width_ << 2) > size_) {
+    if (y_ == 0) {
+      size_ = (std::max)(height_, 16) << 4;  // was << 2
+      data_ = SafeMalloc(size_);
+    } else if (y_ < height_) {
+      int prev_size = size_;
+      int new_size1 = (p_ / y_) * height_ + (width_ << 4);
+      int new_size2 = size_ << 1;
+      size_ = (std::max)(new_size1, new_size2);
+      SafeRealloc(data_, size_);
+    }
+  }
+
+  MaskFinalise();
+  first_ = true;
+}
+
+void Flex::Shrink() {
+  SafeRealloc(data_, p_);
+  end_p_ = p_;
+}
+
+void Flex::Write32(uint32_t w) {
+  *((uint32_t*)&data_.get()[p_]) = w;
+  p_ += 4;
+}
+void Flex::Write64(uint64_t w) {
+  *((uint64_t*)&data_.get()[p_]) = w;
+  p_ += 8;
+}
+
+void Flex::MaskWrite(int count, bool white) {
+  if (first_) {
+    mask_count_ = count;
+    mask_white_ = white;
+    first_ = false;
+  } else {
+    if (white == mask_white_) {
+      mask_count_ += count;
+    } else {
+      Write32((static_cast<int>(mask_white_) << 31) | mask_count_);
+      mask_count_ = count;
+      mask_white_ = white;
+    }
+  }
+}
+
+void Flex::MaskFinalise() {
+  if (mask_count_ != 0) {
+    Write32((static_cast<int>(mask_white_) << 31) | mask_count_);
+  }
+}
+
+void Flex::IncrementLast32(int inc) const {
+  *((uint32_t*)&data_.get()[p_ - 4]) += inc;
+}
+
+uint8_t Flex::ReadBackwards8() { return data_.get()[--p_]; }
+uint16_t Flex::ReadBackwards16() { return *((uint16_t*)&data_.get()[p_ -= 2]); }
+uint32_t Flex::ReadBackwards32() { return *((uint32_t*)&data_.get()[p_ -= 4]); }
+uint64_t Flex::ReadBackwards64() { return *((uint64_t*)&data_.get()[p_ -= 8]); }
+
+uint32_t Flex::ReadForwards32() {
+  uint32_t out = *((uint32_t*)&data_.get()[p_]);
+  p_ += 4;
+  return out;
+}
+
+void Flex::Copy(uint8_t* src, int len) {
+  memcpy(&data_.get()[p_], src, len);
+  p_ += len;
+}
+
+void Flex::Start() { p_ = 0; }
+
+void Flex::End() { p_ = end_p_; }
 
 /***********************************************************************
  * ShrinkMasks

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -274,7 +274,7 @@ Options:
           utils::Throw("Error: Bad --cache-threshold parameter");
         }
       }
-      memory::MapAlloc::CacheThreshold(threshold);
+      memory::CacheThreshold(threshold);
     } else if ((strcmp(my_argv[pos], "--nomask") == 0) ||
                (strcmp(my_argv[pos], "--no-mask") == 0)) {
       no_mask = true;
@@ -348,7 +348,7 @@ Options:
     } else if ((strcmp(my_argv[pos], "--tempdir") == 0) ||
                (strcmp(my_argv[pos], "--tmpdir") == 0) &&
                    pos < (int)my_argv.size() - 1) {
-      memory::MapAlloc::SetTmpdir(my_argv[++pos]);
+      memory::SetTmpdir(my_argv[++pos]);
     } else if (strcmp(my_argv[pos], "--all-threads") == 0) {
       all_threads = true;
     } else if ((strcmp(my_argv[pos], "-o") == 0) ||

--- a/src/mapalloc.cpp
+++ b/src/mapalloc.cpp
@@ -5,17 +5,11 @@
 
 namespace multiblend::memory {
 
-void* MapAlloc::Alloc(std::size_t size, int alignment) {
-  return _aligned_malloc(size, alignment);
-}
-
-void MapAlloc::Free(void* p) { _aligned_free(p); }
-
-void MapAlloc::CacheThreshold(std::size_t limit) {
+void CacheThreshold(std::size_t limit) {
   utils::Throw("MapAlloc::CacheThreshold not implemented");
 }
 
-void MapAlloc::SetTmpdir(const char* _tmpdir) {
+void SetTmpdir(const char* _tmpdir) {
   utils::Throw("MapAlloc::SetTmpdir not implemented");
 }
 

--- a/src/multiblend.cpp
+++ b/src/multiblend.cpp
@@ -112,8 +112,7 @@ Result Multiblend(std::vector<io::Image>& images, Options opts) {
   /***********************************************************************
    * Allocate working space for reading/trimming/extraction
    ***********************************************************************/
-  auto untrimmed_data =
-      memory::MapAllocPtr<void>{memory::MapAlloc::Alloc(untrimmed_bytes)};
+  auto untrimmed_data = memory::AllocAligned<void>(untrimmed_bytes);
 
   /***********************************************************************
    * Read/trim/extract
@@ -902,8 +901,8 @@ Result Multiblend(std::vector<io::Image>& images, Options opts) {
   /***********************************************************************
    * No output?
    ***********************************************************************/
-  std::array<memory::MapAllocPtr<void>, 3> output_channels = {nullptr, nullptr,
-                                                              nullptr};
+  std::array<memory::AlignedAllocPtr<void>, 3> output_channels = {
+      nullptr, nullptr, nullptr};
 
   if (opts.output_type != io::ImageType::MB_NONE) {
     /***********************************************************************
@@ -1004,8 +1003,7 @@ Result Multiblend(std::vector<io::Image>& images, Options opts) {
       }
 
       auto temp =
-          std::shared_ptr<float>{(float*)memory::MapAlloc::Alloc(max_bytes),
-                                 memory::MapAllocDeleter{}};
+          std::shared_ptr<float>(memory::AllocAligned<float>(max_bytes));
 
       if (level < blend_levels) {
         for (auto& image : images) {
@@ -1026,9 +1024,8 @@ Result Multiblend(std::vector<io::Image>& images, Options opts) {
     auto output_pyramid = Pyramid{width, height, total_levels, 0, 0};
 
     for (int level = total_levels - 1; level >= 0; --level) {
-      output_pyramid.GetLevel(level).data = {
-          (float*)memory::MapAlloc::Alloc(output_pyramid.GetLevel(level).bytes),
-          memory::MapAllocDeleter{}};
+      output_pyramid.GetLevel(level).data =
+          memory::AllocAligned<float>(output_pyramid.GetLevel(level).bytes);
     }
 
     /***********************************************************************
@@ -1265,8 +1262,8 @@ Result Multiblend(std::vector<io::Image>& images, Options opts) {
        ***********************************************************************/
       timer.Start();
 
-      output_channels[c] = memory::MapAllocPtr<void>{memory::MapAlloc::Alloc(
-          ((std::size_t)width * height) << (opts.output_bpp >> 4))};
+      output_channels[c] = memory::AllocAligned<void>(
+          ((std::size_t)width * height) << (opts.output_bpp >> 4));
 
       switch (opts.output_bpp) {
         case 8:

--- a/src/pyramid.cpp
+++ b/src/pyramid.cpp
@@ -93,8 +93,7 @@ Pyramid::Pyramid(int width, int height, int _levels, int x, int y) {
   lines_.resize(threadpool_->GetNThreads());
 
   for (int i = 0; i < threadpool_->GetNThreads(); ++i) {
-    lines_[i] = memory::AlignedM128Ptr{
-        (__m128*)_aligned_malloc(levels_[0].pitch * sizeof(float), 16)};
+    lines_[i] = memory::AllocAlignedM128(levels_[0].pitch * sizeof(float));
   }
 }
 
@@ -961,9 +960,9 @@ void Pyramid::LaplaceThreadWrapper(Level* upper_level, Level* lower_level,
                                    int sy, int ey) {
   int temp = upper_level->m128_pitch << 4;
 
-  auto temp1 = memory::AlignedM128Ptr{(__m128*)_aligned_malloc(temp, 16)};
-  auto temp2 = memory::AlignedM128Ptr{(__m128*)_aligned_malloc(temp, 16)};
-  auto temp3 = memory::AlignedM128Ptr{(__m128*)_aligned_malloc(temp, 16)};
+  auto temp1 = memory::AllocAlignedM128(temp);
+  auto temp2 = memory::AllocAlignedM128(temp);
+  auto temp3 = memory::AllocAlignedM128(temp);
 
   LaplaceThread(upper_level, lower_level, sy, ey, temp1.get(), temp2.get(),
                 temp3.get());


### PR DESCRIPTION
- Use [operator new](https://en.cppreference.com/w/cpp/memory/new/operator_new) instead of `memalign` + `_aligned_malloc`
- Check return values from `malloc` + `realloc`